### PR TITLE
Update first_run.sh

### DIFF
--- a/scripts/first_run.sh
+++ b/scripts/first_run.sh
@@ -17,7 +17,7 @@ EOF
 echo "Creating user: \"$USER\"..."
 cat > /etc/rabbitmq/rabbitmq.config <<EOF
 [
-	{rabbit, [{default_user, <<"$USER">>},{default_pass, <<"$PASS">>},{default_vhost, <<"$VHOST">>},{tcp_listeners, [{"0.0.0.0", 5672}]}]}
+        {rabbit, [{default_user, <<"$USER">>},{default_pass, <<"$PASS">>},{default_vhost, <<"$VHOST">>},{tcp_listeners, [{"0.0.0.0", 5672}]},{vm_memory_high_watermark, {absolute, "196MiB"}}]}
 ].
 EOF
 


### PR DESCRIPTION
RabbitMQ requires an absolute high watermark in the docker container
